### PR TITLE
Fix indexing error and other issues

### DIFF
--- a/dexcandles-v2.graphql
+++ b/dexcandles-v2.graphql
@@ -29,11 +29,11 @@ type Candle @entity {
   period: Int!
   lastBlock: Int!
 
-  tokenX: Bytes!
-  tokenY: Bytes!
+  token0: Bytes!
+  token1: Bytes!
 
-  tokenXTotalAmount: BigDecimal!
-  tokenYTotalAmount: BigDecimal!
+  token0TotalAmount: BigInt!
+  token1TotalAmount: BigInt!
 
   high: BigDecimal!
   open: BigDecimal!

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
-import { BigDecimal } from "@graphprotocol/graph-ts";
+import { BigDecimal, BigInt } from "@graphprotocol/graph-ts";
 
 export const candlestickPeriods: i32[] = [
   5 * 60, // 5m
@@ -9,6 +9,7 @@ export const candlestickPeriods: i32[] = [
   7 * 24 * 60 * 60, // 1w
 ];
 
+export const BIG_INT_ZERO = BigInt.fromI32(0);
 export const BIG_DECIMAL_ONE = BigDecimal.fromString("1");
 export const BIG_DECIMAL_ZERO = BigDecimal.fromString("0");
 export const NULL_CALL_RESULT_VALUE =

--- a/src/dexcandles-v2.ts
+++ b/src/dexcandles-v2.ts
@@ -16,7 +16,7 @@ export function handleSwapV2(event: SwapV2): void {
   const tokenY = loadToken(Address.fromString(lbPair.tokenY));
 
   // init token0/token1 to match with V1Pair's tokens order
-  const isSorted = tokenX.id < tokenY.id; // if true, order of tokens matches V1Pair
+  const isSorted = tokenX.id.toLowerCase() < tokenY.id.toLowerCase(); // if true, order of tokens matches V1Pair
   const token0 = isSorted ? tokenX : tokenY;
   const token1 = isSorted ? tokenY : tokenX;
 
@@ -35,8 +35,8 @@ export function handleSwapV2(event: SwapV2): void {
   const price = isSorted ? priceX : priceY;
 
   // debug log
-  log.warning("[handleSwapV2] token0 {} / token1 {}", [token0.id, token1.id])
-  log.warning("[handleSwapV2] price {}", [price.toString()])
+  log.warning("[handleSwapV2] token0 {} / token1 {}", [token0.id, token1.id]);
+  log.warning("[handleSwapV2] price {}", [price.toString()]);
 
   for (let i = 0; i < candlestickPeriods.length; i++) {
     const timestamp = event.block.timestamp.toI32();
@@ -44,8 +44,8 @@ export function handleSwapV2(event: SwapV2): void {
     const candleId = periodStart
       .toString()
       .concat(candlestickPeriods[i].toString())
-      .concat(tokenX.id)
-      .concat(tokenY.id);
+      .concat(token0.id)
+      .concat(token1.id);
 
     let candle = Candle.load(candleId);
     if (!candle) {

--- a/src/dexcandles-v2.ts
+++ b/src/dexcandles-v2.ts
@@ -1,10 +1,10 @@
-import { Address, BigDecimal } from "@graphprotocol/graph-ts";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 import { Swap as SwapV1 } from "../generated/Pair/Pair";
 import { Swap as SwapV2 } from "../generated/LBPair/LBPair";
 import { Candle, LBPair } from "../generated/schema";
 import { loadToken, loadV1Pair } from "./entities";
 import { getTokenYPriceOfBin, getAmountTraded } from "./utils/pricing";
-import { BIG_DECIMAL_ONE, BIG_DECIMAL_ZERO, candlestickPeriods } from "./constants";
+import { BIG_INT_ZERO, BIG_DECIMAL_ONE, candlestickPeriods } from "./constants";
 
 export function handleSwapV2(event: SwapV2): void {
   const lbPair = LBPair.load(event.address.toHexString());
@@ -15,13 +15,24 @@ export function handleSwapV2(event: SwapV2): void {
   const tokenX = loadToken(Address.fromString(lbPair.tokenX));
   const tokenY = loadToken(Address.fromString(lbPair.tokenY));
 
+  // init token0/token1 to match with V1Pair's tokens order
+  const isSorted = tokenX.id < tokenY.id; // if true, order of tokens matches V1Pair
+  const token0 = isSorted ? tokenX : tokenY;
+  const token1 = isSorted ? tokenY : tokenX;
+
+  // price in tokenY
   const priceY = getTokenYPriceOfBin(
     event.params.id,
     lbPair.binStep,
     tokenX,
     tokenY
   );
+
+  // price in tokenX
   const priceX = BIG_DECIMAL_ONE.div(priceY);
+
+  // price in token0
+  const price = isSorted ? priceX : priceY;
 
   for (let i = 0; i < candlestickPeriods.length; i++) {
     const timestamp = event.block.timestamp.toI32();
@@ -37,36 +48,36 @@ export function handleSwapV2(event: SwapV2): void {
       candle = new Candle(candleId);
       candle.time = periodStart;
       candle.period = candlestickPeriods[i];
-      candle.tokenX = Address.fromString(tokenX.id);
-      candle.tokenY = Address.fromString(tokenY.id);
-      candle.tokenXTotalAmount = BIG_DECIMAL_ZERO;
-      candle.tokenYTotalAmount = BIG_DECIMAL_ZERO;
-      candle.high = priceX;
-      candle.open = priceX;
-      candle.close = priceX;
-      candle.low = priceX;
+      candle.token0 = Address.fromString(token0.id);
+      candle.token1 = Address.fromString(token1.id);
+      candle.token0TotalAmount = BIG_INT_ZERO;
+      candle.token1TotalAmount = BIG_INT_ZERO;
+      candle.high = price;
+      candle.open = price;
+      candle.close = price;
+      candle.low = price;
     }
 
-    const amountXTraded = (event.params.swapForY 
-      ? event.params.amountIn 
-      : event.params.amountOut)
-      .divDecimal(BigDecimal.fromString(tokenX.decimals.toString()))
+    const amountXTraded = event.params.swapForY
+      ? getAmountTraded(event.params.amountIn, BIG_INT_ZERO, tokenX.decimals)
+      : getAmountTraded(BIG_INT_ZERO, event.params.amountOut, tokenX.decimals);
+    const amountYTraded = event.params.swapForY
+      ? getAmountTraded(BIG_INT_ZERO, event.params.amountOut, tokenX.decimals)
+      : getAmountTraded(event.params.amountIn, BIG_INT_ZERO, tokenX.decimals);
 
-    const amountYTraded = (event.params.swapForY 
-        ? event.params.amountOut
-        : event.params.amountIn)
-        .divDecimal(BigDecimal.fromString(tokenY.decimals.toString()))
+    const amount0Traded = isSorted ? amountXTraded : amountYTraded;
+    const amount1Traded = isSorted ? amountYTraded : amountXTraded;
 
-    candle.tokenXTotalAmount = candle.tokenXTotalAmount.plus(amountXTraded);
-    candle.tokenYTotalAmount = candle.tokenYTotalAmount.plus(amountYTraded);
+    candle.token0TotalAmount = candle.token0TotalAmount.plus(amount0Traded);
+    candle.token1TotalAmount = candle.token1TotalAmount.plus(amount1Traded);
 
-    if (priceX.lt(candle.low)) {
-      candle.low = priceX;
+    if (price.lt(candle.low)) {
+      candle.low = price;
     }
-    if (priceX.gt(candle.high)) {
-      candle.high = priceX;
+    if (price.gt(candle.high)) {
+      candle.high = price;
     }
-    candle.close = priceX;
+    candle.close = price;
     candle.lastBlock = event.block.timestamp.toI32();
 
     candle.save();
@@ -82,17 +93,22 @@ export function handleSwapV1(event: SwapV1): void {
   const token0 = loadToken(Address.fromString(v1Pair.token0));
   const token1 = loadToken(Address.fromString(v1Pair.token1));
 
-  const amount0Traded = getAmountTraded(
+  const amount0Traded: BigInt = getAmountTraded(
     event.params.amount0In,
     event.params.amount0Out,
     token0.decimals
   );
-  const amount1Traded = getAmountTraded(
+  const amount1Traded: BigInt = getAmountTraded(
     event.params.amount1In,
     event.params.amount1Out,
     token1.decimals
   );
-  const price = amount0Traded.div(amount1Traded);
+
+  if (amount0Traded.isZero() || amount1Traded.isZero()) {
+    return;
+  }
+
+  const price = amount0Traded.divDecimal(amount1Traded.toBigDecimal());
 
   for (let i = 0; i < candlestickPeriods.length; i++) {
     const timestamp = event.block.timestamp.toI32();
@@ -108,18 +124,18 @@ export function handleSwapV1(event: SwapV1): void {
       candle = new Candle(candleId);
       candle.time = periodStart;
       candle.period = candlestickPeriods[i];
-      candle.tokenX = Address.fromString(token0.id);
-      candle.tokenY = Address.fromString(token1.id);
-      candle.tokenXTotalAmount = BIG_DECIMAL_ZERO;
-      candle.tokenYTotalAmount = BIG_DECIMAL_ZERO;
+      candle.token0 = Address.fromString(token0.id);
+      candle.token1 = Address.fromString(token1.id);
+      candle.token0TotalAmount = BIG_INT_ZERO;
+      candle.token1TotalAmount = BIG_INT_ZERO;
       candle.high = price;
       candle.open = price;
       candle.close = price;
       candle.low = price;
     }
 
-    candle.tokenXTotalAmount = candle.tokenXTotalAmount.plus(amount0Traded);
-    candle.tokenYTotalAmount = candle.tokenYTotalAmount.plus(amount1Traded);
+    candle.token0TotalAmount = candle.token0TotalAmount.plus(amount0Traded);
+    candle.token1TotalAmount = candle.token1TotalAmount.plus(amount1Traded);
 
     if (price.lt(candle.low)) {
       candle.low = price;

--- a/src/dexcandles-v2.ts
+++ b/src/dexcandles-v2.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { Address, BigInt, log } from "@graphprotocol/graph-ts";
 import { Swap as SwapV1 } from "../generated/Pair/Pair";
 import { Swap as SwapV2 } from "../generated/LBPair/LBPair";
 import { Candle, LBPair } from "../generated/schema";
@@ -33,6 +33,10 @@ export function handleSwapV2(event: SwapV2): void {
 
   // price in token0
   const price = isSorted ? priceX : priceY;
+
+  // debug log
+  log.warning("[handleSwapV2] token0 {} / token1 {}", [token0.id, token1.id])
+  log.warning("[handleSwapV2] price {}", [price.toString()])
 
   for (let i = 0; i < candlestickPeriods.length; i++) {
     const timestamp = event.block.timestamp.toI32();

--- a/src/dexcandles-v2.ts
+++ b/src/dexcandles-v2.ts
@@ -1,8 +1,8 @@
 import { Address, BigDecimal } from "@graphprotocol/graph-ts";
 import { Swap as SwapV1 } from "../generated/Pair/Pair";
 import { Swap as SwapV2 } from "../generated/LBPair/LBPair";
-import { Candle, LBPair, Pair } from "../generated/schema";
-import { loadToken } from "./entities";
+import { Candle, LBPair } from "../generated/schema";
+import { loadToken, loadV1Pair } from "./entities";
 import { getTokenYPriceOfBin, getAmountTraded } from "./utils/pricing";
 import { BIG_DECIMAL_ONE, BIG_DECIMAL_ZERO, candlestickPeriods } from "./constants";
 
@@ -74,7 +74,7 @@ export function handleSwapV2(event: SwapV2): void {
 }
 
 export function handleSwapV1(event: SwapV1): void {
-  const v1Pair = Pair.load(event.address.toHexString());
+  const v1Pair = loadV1Pair(event.address);
   if (!v1Pair) {
     return;
   }

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,1 +1,2 @@
 export * from "./token";
+export * from "./pairV1";

--- a/src/entities/pairV1.ts
+++ b/src/entities/pairV1.ts
@@ -1,0 +1,38 @@
+import { Address, log } from "@graphprotocol/graph-ts";
+import { Pair as PairV1 } from "../../generated/schema";
+import { Pair as PairContract } from "../../generated/Pair/Pair";
+import { loadToken } from "./token";
+
+export function loadV1Pair(address: Address): PairV1 | null {
+  let v1Pair = PairV1.load(address.toHexString());
+
+  if (!v1Pair) {
+    const pair = PairContract.bind(address);
+
+    // get token0
+    const token0Result = pair.try_token0();
+    if (token0Result.reverted) {
+      log.info("[loadV1Pair] try_token0 reverted", []);
+      return null;
+    }
+
+    // get token1
+    const token1Result = pair.try_token1();
+    if (token1Result.reverted) {
+      log.info("[loadV1Pair] try_token1 reverted", []);
+      return null;
+    }
+
+    // create Tokens
+    const token0 = loadToken(token0Result.value);
+    const token1 = loadToken(token1Result.value);
+
+    // create PairV1
+    v1Pair = new PairV1(address.toHexString());
+    v1Pair.token0 = token0.id;
+    v1Pair.token1 = token1.id;
+    v1Pair.save();
+  }
+
+  return v1Pair as PairV1;
+}

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -46,22 +46,36 @@ export function getTokenYPriceOfBin(
 }
 
 /**
- * Returns the total amount traded given the amount in
- * and amout out of an LBPair
+ * Returns the total amount traded in 18 decimals precision
  *
  * @param { BigInt } amountIn
  * @param { BigInt } amountOut
  * @param { BigInt } decimals
- * @returns { BigDecimal }
+ * @returns { BigInt }
  */
 export function getAmountTraded(
   amountIn: BigInt,
   amountOut: BigInt,
   tokenDecimals: BigInt
-): BigDecimal {
-  const decimals = BigDecimal.fromString(tokenDecimals.toString());
-  return amountIn
-    .minus(amountOut)
-    .abs()
-    .divDecimal(decimals);
+): BigInt {
+  const exponent = BigInt.fromI32(18).minus(tokenDecimals);
+  if (exponent >= BigInt.fromI32(0)) {
+    const multiplier = BigInt.fromString(
+      BigDecimal.fromString("1e" + exponent.toString()).toString()
+    );
+    return amountIn
+      .minus(amountOut)
+      .abs()
+      .times(multiplier);
+  } else {
+    const divider = BigInt.fromString(
+      BigDecimal.fromString(
+        "1e" + exponent.times(BigInt.fromI32(-1)).toString()
+      ).toString()
+    );
+    return amountIn
+      .minus(amountOut)
+      .abs()
+      .div(divider);
+  }
 }


### PR DESCRIPTION
This PR addresses the following issues:

- We were not handling 0 div properly, which caused indexing error
- We won't sync this subgraph from the beginning of JoePair factory. Therefore, V1Pairs need to be created on demand
- `getAmountTraded()` implementation was incorrect
- LBPair's tokenX/tokenY and V1Pair's token0/token1 could be in different sorted order. 

Note:
- We now make a distinction between tokenX/tokenY and token0/token1
- `token0/token1` is based on V1Pair's tokens order
- `tokenX/tokenY` is based on LBPair's tokens order
- `Candles` will be tracked based on V1Pair's tokens order